### PR TITLE
Correcting Vignette title in description

### DIFF
--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -4,7 +4,7 @@ author: "Evan Odell"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Vignette Title}
+  %\VignetteIndexEntry{Introduction to ukpolice package}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
Hi, 

Nice job on this package - looking forward to going through it when I have some time. 

Looking at the description on CRAN I saw that the vignette title was missing (i.e listed the vignette as Vignette Title). Change below should correct this.

Thanks, 

Sam